### PR TITLE
feat(smtp): delete localhost check

### DIFF
--- a/smtp.js
+++ b/smtp.js
@@ -49,9 +49,6 @@ var server = new SMTPServer({
     });
   },
   onConnect: function (session, callback) {
-    if (session.remoteAddress !== '127.0.0.1') {
-      return callback(new Error('Only connections from localhost allowed'));
-    }
     return callback(); // Accept the connection
   },
   onData: function (stream, session, callback) {


### PR DESCRIPTION
Allow mail server connections outside from localhost, e.g. when starting
the mail server in docker. It opens no security issues because there is no real mail sending.
Also it makes no sense to overwrite the SMSMTP_BIND when the check for the bind address
127.0.0.1 exists.